### PR TITLE
support cascade directive

### DIFF
--- a/edge.go
+++ b/edge.go
@@ -16,6 +16,7 @@ type edge struct {
 	Order      []DQLizer
 	Group      []DQLizer
 	Facets     []DQLizer
+	Cascade    DQLizer
 	IsRoot     bool
 	IsVariable bool
 }
@@ -122,6 +123,10 @@ func (edge edge) ToDQL() (query string, args []interface{}, err error) {
 		return "", nil, err
 	}
 
+	if err := edge.addCascade(&writer, &args); err != nil {
+		return "", nil, err
+	}
+
 	writer.WriteString(" { ")
 
 	if err := edge.addSelection(&writer, &args); err != nil {
@@ -186,6 +191,22 @@ func (edge edge) addGroupBy(writer *bytes.Buffer, args *[]interface{}) error {
 	writer.WriteString(strings.Join(statements, ","))
 
 	writer.WriteString(")")
+	return nil
+}
+
+func (edge edge) addCascade(writer *bytes.Buffer, args *[]interface{}) error {
+	if edge.Cascade == nil {
+		return nil
+	}
+
+	writer.WriteString(" ")
+
+	var statements []string
+	if err := addStatement([]DQLizer{edge.Cascade}, &statements, args); err != nil {
+		return err
+	}
+
+	writer.WriteString(strings.Join(statements, " "))
 	return nil
 }
 

--- a/expression.go
+++ b/expression.go
@@ -717,6 +717,30 @@ func GroupBy(name string) DQLizer {
 	return group{name}
 }
 
+type cascadeExpr struct {
+	fields []string
+}
+
+// Cascade returns an expression for cascade directive
+func Cascade(fields ...string) DQLizer {
+	return cascadeExpr{fields}
+}
+
+// ToDQL returns the DQL statement for the 'cascade' expression
+func (cascade cascadeExpr) ToDQL() (query string, args []interface{}, err error) {
+	if len(cascade.fields) > 0 {
+		fields := make([]string, len(cascade.fields))
+
+		for index, field := range cascade.fields {
+			fields[index] = fmt.Sprintf(`"%s"`, field)
+		}
+
+		return fmt.Sprintf("@cascade(fields: [%s])", strings.Join(fields, ",")), nil, nil
+	}
+
+	return "@cascade", nil, nil
+}
+
 type facetExpr struct {
 	Predicates []interface{}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/dgraph-io/dgo/v200 v200.0.0-20210401091508-95bfd74de60e
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/stretchr/testify v1.7.0

--- a/query.go
+++ b/query.go
@@ -197,6 +197,13 @@ func (builder QueryBuilder) GroupBy(predicates ...string) QueryBuilder {
 	return builder
 }
 
+// Cascade adds cascade directive
+func (builder QueryBuilder) Cascade(fields ...string) QueryBuilder {
+	builder.rootEdge.Cascade = Cascade(fields...)
+
+	return builder
+}
+
 // Edge adds an edge in the query selection
 // Example1: dqlx.Query(...).Edge("path")
 // Example2: dqlx.Query(...).Edge("parent->child->child")
@@ -217,6 +224,8 @@ func (builder QueryBuilder) Edge(fullPath string, queryParts ...DQLizer) QueryBu
 				builder = builder.GroupBy(cast.Predicate)
 			case facetExpr:
 				builder = builder.Facets(cast.Predicates...)
+			case cascadeExpr:
+				builder = builder.Cascade(cast.fields...)
 			case DQLizer:
 				builder = builder.Filter(cast)
 			}


### PR DESCRIPTION
Support cascade directive

```go
	query, variables, err := dql.
		QueryEdge("bladerunner", dql.EqFn("item", "value")).
		Fields(`
			uid
			name
			initial_release_date
			netflix_id
		`).
		Cascade().
		Edge("films", dql.Fields(`
			id
			date
		`), dql.Cascade("date", "id")).
		ToDQL()
```

Closes #3 