### PR TITLE
Append the individual elements of select args, not the slice

### DIFF
--- a/query_operation_test.go
+++ b/query_operation_test.go
@@ -54,3 +54,33 @@ func Test_Multiple_Blocks(t *testing.T) {
 
 	require.Equal(t, expected, query)
 }
+
+func TestMultipleQueriesWithSelect(t *testing.T) {
+	q1 := dql.Query(dql.EqFn("id", "id_a")).
+		Select(dql.As("id_a", "id"))
+
+	q2 := dql.Query(dql.EqFn("id", "id_b")).
+		Select(dql.As("id_b", "id"))
+
+	query, variables, err := dql.QueriesToDQL(q1, q2)
+
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]string{
+		"$0": "id_a",
+		"$1": "id_b",
+	}, variables)
+
+	expected := dql.Minify(`
+		query Rootquery_Rootquery_1($0:string, $1:string) { 
+          <rootQuery>(func: eq(<id>,$0)) { 
+            id_a AS <id> 
+          } 
+          <rootQuery_1>(func: eq(<id>,$1)) {
+            id_b AS <id>
+          } 
+        }
+	`)
+
+	require.Equal(t, expected, query)
+}

--- a/query_operation_test.go
+++ b/query_operation_test.go
@@ -55,7 +55,7 @@ func Test_Multiple_Blocks(t *testing.T) {
 	require.Equal(t, expected, query)
 }
 
-func TestMultipleQueriesWithSelect(t *testing.T) {
+func Test_Multiple_Blocks_With_Select(t *testing.T) {
 	q1 := dql.Query(dql.EqFn("id", "id_a")).
 		Select(dql.As("id_a", "id"))
 

--- a/selection.go
+++ b/selection.go
@@ -81,7 +81,7 @@ func (fields nodeAttributes) ToDQL() (query string, args []interface{}, err erro
 				return "", nil, err
 			}
 
-			args = append(args, computedArgs)
+			args = append(args, computedArgs...)
 			selectedFields = append(selectedFields, computedDql)
 		case string:
 			fieldString := parsePredicates(requestField)


### PR DESCRIPTION
When appending the computed arguments from a select, the slice of arguments was being appended, not the individual elements.

Note that this also resolves the `TestExampleTestSuite/TestFundamentals/Applying_filters` that has been failing.

