### PR TITLE
Abate surrounding the field name with angle brackets for the expand() dgraph function

### DIFF
--- a/edge.go
+++ b/edge.go
@@ -43,7 +43,11 @@ func (edge edge) ToDQL() (query string, args []interface{}, err error) {
 	} else {
 		if !(edge.IsRoot && edge.IsVariable) {
 			if edgeName != "" {
-				writer.WriteString(fmt.Sprintf("<%s>", edgeName))
+				if strings.HasPrefix(edgeName, "expand(") {
+					writer.WriteString(edgeName)
+				} else {
+					writer.WriteString(fmt.Sprintf("<%s>", edgeName))
+				}
 			}
 		}
 	}

--- a/predicate.go
+++ b/predicate.go
@@ -233,6 +233,9 @@ func EscapePredicate(field string) string {
 		alias = fmt.Sprintf("<%s>:", alias)
 	}
 
+	if strings.HasPrefix(field, "expand(") {
+		return fmt.Sprintf("%s%s%s", alias, field, directive)
+	}
 	return fmt.Sprintf("%s<%s>%s", alias, field, directive)
 }
 


### PR DESCRIPTION
Dgraph's [expand](https://dgraph.io/docs/query-language/expand-predicates/#) function can't be surrounded with angle brackets.

cc @fenos

closes #17 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>